### PR TITLE
Source File Roots

### DIFF
--- a/code/compiler/core-tests/build-engine-unit-tests.wren
+++ b/code/compiler/core-tests/build-engine-unit-tests.wren
@@ -77,7 +77,7 @@ class BuildEngineUnitTests {
 		arguments.ObjectDirectory = Path.new("obj/")
 		arguments.BinaryDirectory = Path.new("bin/")
 		arguments.SourceFiles = [
-			SourceFile.new(Path.new("TestFile.cpp"), null, false, null, []),
+			SourceFile.new(Path.new("TestFile.cpp"), Path.new("./"), null, false, null, []),
 		]
 		arguments.OptimizationLevel = BuildOptimizationLevel.None
 		arguments.LinkDependencies = [
@@ -236,7 +236,7 @@ class BuildEngineUnitTests {
 		arguments.ObjectDirectory = Path.new("obj/")
 		arguments.BinaryDirectory = Path.new("bin/")
 		arguments.SourceFiles = [
-			SourceFile.new(Path.new("TestFile.cpp"), null, false, null, []),
+			SourceFile.new(Path.new("TestFile.cpp"), Path.new("./"), null, false, null, []),
 		]
 		arguments.ResourceFile = Path.new("Resources.rc")
 		arguments.OptimizationLevel = BuildOptimizationLevel.None
@@ -403,7 +403,7 @@ class BuildEngineUnitTests {
 		arguments.ObjectDirectory = Path.new("obj/")
 		arguments.BinaryDirectory = Path.new("bin/")
 		arguments.SourceFiles = [
-			SourceFile.new(Path.new("TestFile.cpp"), null, false, null, []),
+			SourceFile.new(Path.new("TestFile.cpp"), Path.new("./"), null, false, null, []),
 		]
 		arguments.OptimizationLevel = BuildOptimizationLevel.None
 		arguments.LinkDependencies = [
@@ -570,7 +570,7 @@ class BuildEngineUnitTests {
 		arguments.ObjectDirectory = Path.new("obj/")
 		arguments.BinaryDirectory = Path.new("bin/")
 		arguments.SourceFiles = [
-			SourceFile.new(Path.new("TestFile1.cpp"), null, false, null, []),
+			SourceFile.new(Path.new("TestFile1.cpp"), Path.new("./"), null, false, null, []),
 		]
 		arguments.PublicHeaderSets = [
 			HeaderFileSet.new(
@@ -841,9 +841,9 @@ class BuildEngineUnitTests {
 		arguments.ObjectDirectory = Path.new("obj/")
 		arguments.BinaryDirectory = Path.new("bin/")
 		arguments.SourceFiles = [
-			SourceFile.new(Path.new("TestFile1.cpp"), null, false, null, []),
-			SourceFile.new(Path.new("TestFile2.cpp"), null, false, null, []),
-			SourceFile.new(Path.new("TestFile3.cpp"), null, false, null, []),
+			SourceFile.new(Path.new("TestFile1.cpp"), Path.new("./"), null, false, null, []),
+			SourceFile.new(Path.new("TestFile2.cpp"), Path.new("./"), null, false, null, []),
+			SourceFile.new(Path.new("TestFile3.cpp"), Path.new("./"), null, false, null, []),
 		]
 		arguments.OptimizationLevel = BuildOptimizationLevel.Size
 		arguments.IncludeDirectories = [
@@ -1076,10 +1076,10 @@ class BuildEngineUnitTests {
 		arguments.ObjectDirectory = Path.new("obj/")
 		arguments.BinaryDirectory = Path.new("bin/")
 		arguments.SourceFiles = [
-			SourceFile.new(Path.new("Public.cpp"), "Library", true, null, []),
-			SourceFile.new(Path.new("TestFile1.cpp"), null, false, null, []),
-			SourceFile.new(Path.new("TestFile2.cpp"), null, false, null, []),
-			SourceFile.new(Path.new("TestFile3.cpp"), null, false, null, []),
+			SourceFile.new(Path.new("Public.cpp"), Path.new("./"), "Library", true, null, []),
+			SourceFile.new(Path.new("TestFile1.cpp"), Path.new("./"), null, false, null, []),
+			SourceFile.new(Path.new("TestFile2.cpp"), Path.new("./"), null, false, null, []),
+			SourceFile.new(Path.new("TestFile3.cpp"), Path.new("./"), null, false, null, []),
 		]
 		arguments.OptimizationLevel = BuildOptimizationLevel.None
 		arguments.IncludeDirectories = [
@@ -1347,6 +1347,7 @@ class BuildEngineUnitTests {
 		arguments.SourceFiles = [
 			SourceFile.new(
 				Path.new("Public.cpp"),
+				Path.new("./"),
 				"Library",
 				true,
 				null,
@@ -1356,20 +1357,22 @@ class BuildEngineUnitTests {
 				]),
 			SourceFile.new(
 				Path.new("TestFile1.cpp"),
+				Path.new("./"),
 				"Library",
 				true,
 				"TestFile1",
 				[]),
 			SourceFile.new(
 				Path.new("TestFile2.cpp"),
+				Path.new("./"),
 				"Library",
 				true,
 				"TestFile2",
 				[
 					":TestFile1",
 				]),
-			SourceFile.new(Path.new("TestFile3.cpp"), null, false, null, []),
-			SourceFile.new(Path.new("TestFile4.cpp"), null, false, null, []),
+			SourceFile.new(Path.new("TestFile3.cpp"), Path.new("./"), null, false, null, []),
+			SourceFile.new(Path.new("TestFile4.cpp"), Path.new("./"), null, false, null, []),
 		]
 		arguments.OptimizationLevel = BuildOptimizationLevel.None
 		arguments.IncludeDirectories = [
@@ -1669,6 +1672,7 @@ class BuildEngineUnitTests {
 		arguments.SourceFiles = [
 			SourceFile.new(
 				Path.new("Public.cpp"),
+				Path.new("./"),
 				"Library",
 				true,
 				null,
@@ -1679,12 +1683,14 @@ class BuildEngineUnitTests {
 				]),
 			SourceFile.new(
 				Path.new("TestFile1.cpp"),
+				Path.new("./"),
 				"Library",
 				true,
 				"TestFile1",
 				[]),
 			SourceFile.new(
 				Path.new("TestFile2.cpp"),
+				Path.new("./"),
 				"Library",
 				true,
 				"TestFile2",
@@ -1693,13 +1699,14 @@ class BuildEngineUnitTests {
 				]),
 			SourceFile.new(
 				Path.new("TestFile3.cpp"),
+				Path.new("./"),
 				"Library",
 				true,
 				"TestFile3",
 				[
 					":TestFile2",
 				]),
-			SourceFile.new(Path.new("TestFile4.cpp"), null, false, null, []),
+			SourceFile.new(Path.new("TestFile4.cpp"), Path.new("./"), null, false, null, []),
 		]
 		arguments.OptimizationLevel = BuildOptimizationLevel.None
 		arguments.IncludeDirectories = [
@@ -2008,7 +2015,7 @@ class BuildEngineUnitTests {
 		arguments.ObjectDirectory = Path.new("obj/")
 		arguments.BinaryDirectory = Path.new("bin/")
 		arguments.SourceFiles = [
-			SourceFile.new(Path.new("Public.cpp"), "Library", true, null, []),
+			SourceFile.new(Path.new("Public.cpp"), Path.new("./"), "Library", true, null, []),
 		]
 		arguments.OptimizationLevel = BuildOptimizationLevel.Size
 		arguments.IncludeDirectories = [

--- a/code/compiler/core/build-arguments.wren
+++ b/code/compiler/core/build-arguments.wren
@@ -53,22 +53,30 @@ class BuildTargetType {
 class SourceFile {
 	construct new() {
 		_file = null
+		_root = null
 		_module = null
 		_isInterface = null
 		_partition = null
 		_imports = []
 	}
 
-	construct new(file, module, isInterface, partition, imports) {
+	construct new(file, root, module, isInterface, partition, imports) {
 		_file = file
+		_root = root
 		_module = module
 		_isInterface = isInterface
 		_partition = partition
 		_imports = imports
 	}
 
+	// The relative path to the source file
 	File { _file }
 	File=(value) { _file = value }
+
+	// The file root that allows for separation between the relative path of the file
+	// and the source directory. This allows for unique output folders from multiple roots to merge.
+	Root { _root }
+	Root=(value) { _root = value }
 
 	Module { _module }
 	Module=(value) { _module = value }

--- a/code/compiler/core/build-engine.wren
+++ b/code/compiler/core/build-engine.wren
@@ -153,7 +153,7 @@ class BuildEngine {
 
 						var compileFileArguments = ModuleInterfaceUnitCompileArguments.new()
 						compileFileArguments.ModuleName = moduleName
-						compileFileArguments.SourceFile = source.File
+						compileFileArguments.SourceFile = source.Root + source.File
 						compileFileArguments.TargetFile = objectFile
 						compileFileArguments.IncludeModules = imports
 						compileFileArguments.ModuleInterfaceTarget = moduleInterfaceFile
@@ -183,7 +183,7 @@ class BuildEngine {
 						}
 
 						var compileFileArguments = TranslationUnitCompileArguments.new()
-						compileFileArguments.SourceFile = source.File
+						compileFileArguments.SourceFile = source.Root + source.File
 						compileFileArguments.TargetFile = objectFile
 						compileFileArguments.IncludeModules = imports
 

--- a/code/compiler/core/recipe.sml
+++ b/code/compiler/core/recipe.sml
@@ -1,6 +1,6 @@
 Name: 'cpp-compiler'
 Language: 'Wren|0'
-Version: 0.15.0
+Version: 0.16.0
 Dependencies: {
 	Runtime: [
 		'soup|build-utils@0'

--- a/code/extension-tests/tasks/build-task-unit-tests.wren
+++ b/code/extension-tests/tasks/build-task-unit-tests.wren
@@ -51,6 +51,7 @@ class BuildTaskUnitTests {
 		buildTable["Source"] = [
 			{
 				"File": "src/TestFile.cpp",
+				"Root": "./",
 			},
 		]
 
@@ -211,6 +212,7 @@ class BuildTaskUnitTests {
 		buildTable["Source"] = [
 			{
 				"File": "TestFile.cpp",
+				"Root": "./",
 			},
 		]
 
@@ -359,12 +361,15 @@ class BuildTaskUnitTests {
 		buildTable["Source"] = [
 			{
 				"File": "TestFile1.cpp",
+				"Root": "./",
 			},
 			{
 				"File": "TestFile2.cpp",
+				"Root": "./",
 			},
 			{
 				"File": "TestFile3.cpp",
+				"Root": "./",
 			},
 		]
 		buildTable["IncludeDirectories"] = [
@@ -569,17 +574,21 @@ class BuildTaskUnitTests {
 		buildTable["Source"] = [
 			{
 				"File": "Public.cpp",
+				"Root": "./",
 				"IsInterface": true,
 				"Module": "Library",
 			},
 			{
 				"File": "TestFile1.cpp",
+				"Root": "./",
 			},
 			{
 				"File": "TestFile2.cpp",
+				"Root": "./",
 			},
 			{
 				"File": "TestFile3.cpp",
+				"Root": "./",
 			},
 		]
 		buildTable["IncludeDirectories"] = [
@@ -822,6 +831,7 @@ class BuildTaskUnitTests {
 		buildTable["Source"] = [
 			{
 				"File": "Public.cpp",
+				"Root": "./",
 				"Module": "Library",
 				"IsInterface": true,
 				"Imports": [
@@ -831,12 +841,14 @@ class BuildTaskUnitTests {
 			},
 			{
 				"File": "TestFile1.cpp",
+				"Root": "./",
 				"Module": "Library",
 				"IsInterface": true,
 				"Partition": "TestFile1",
 			},
 			{
 				"File": "TestFile2.cpp",
+				"Root": "./",
 				"Module": "Library",
 				"IsInterface": true,
 				"Partition": "TestFile2",
@@ -844,9 +856,11 @@ class BuildTaskUnitTests {
 			},
 			{
 				"File": "TestFile3.cpp",
+				"Root": "./",
 			},
 			{
 				"File": "TestFile4.cpp",
+				"Root": "./",
 			},
 		]
 		buildTable["IncludeDirectories"] = [
@@ -1119,6 +1133,7 @@ class BuildTaskUnitTests {
 		buildTable["Source"] = [
 			{
 				"File": "Public.cpp",
+				"Root": "./",
 				"Module": "Library",
 				"IsInterface": true,
 			}

--- a/code/extension/recipe.sml
+++ b/code/extension/recipe.sml
@@ -1,6 +1,6 @@
 Name: 'cpp'
 Language: 'Wren|0'
-Version: 0.18.1
+Version: 0.18.2
 Dependencies: {
 	Runtime: [
 		'soup|cpp-compiler@0'

--- a/code/extension/tasks/build-task.wren
+++ b/code/extension/tasks/build-task.wren
@@ -72,6 +72,7 @@ class BuildTask is SoupTask {
 			var sourceFiles = []
 			for (source in buildTable["Source"]) {
 				var file = Path.new(source["File"])
+				var root = Path.new(source["Root"])
 
 				var module = null
 				if (source.containsKey("Module")) {
@@ -95,6 +96,7 @@ class BuildTask is SoupTask {
 
 				sourceFiles.add(SourceFile.new(
 					file,
+					root,
 					module,
 					isInterface,
 					partition,

--- a/code/extension/tasks/expand-source-task.wren
+++ b/code/extension/tasks/expand-source-task.wren
@@ -116,6 +116,7 @@ class ExpandSourceTask is SoupTask {
 		var result = preprocessorResult["Result"]
 
 		var sourceInfo = {}
+		sourceInfo["Root"] = "./"
 		sourceInfo["File"] = file.toString
 		sourceInfo["Imports"] = result["Imports"]
 

--- a/run-tests.cmd
+++ b/run-tests.cmd
@@ -4,5 +4,8 @@ SET RootDir=%~dp0
 
 CALL soup build code\extension\
 
-CALL soup run ..\soup\code\generate-test\ -args %RootDir%\code\run-tests.wren %RootDir%\out\wren\local\cpp\0.18.0\J_HqSstV55vlb-x6RWC_hLRFRDU\script\bundles.sml
+REM - Get the target
+for /f %%i in ('soup target code\extension\') do set ExtensionOutputDirectory=%%i
+
+CALL soup run ..\soup\code\generate-test\ -args %RootDir%\code\run-tests.wren %ExtensionOutputDirectory%\script\bundles.sml
 if %ERRORLEVEL% NEQ  0 exit /B %ERRORLEVEL%

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -6,4 +6,7 @@ set -e
 ROOT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 soup build code/extension/
-soup run ../soup/code/generate-test/ -args $ROOT_DIR/code/run-tests.wren $ROOT_DIR/out/wren/local/cpp/0.18.0/J_HqSstV55vlb-x6RWC_hLRFRDU/script/bundles.sml
+
+TARGET_DIR=$(soup target code/extension/ 2>&1)
+
+soup run ../soup/code/generate-test/ -args $ROOT_DIR/code/run-tests.wren $TARGET_DIR/script/bundles.sml


### PR DESCRIPTION
Add ability to specify source file root folder so we can separate generated files being compiled from the target output directory and still use unique folders for the gen object files.